### PR TITLE
13 display extracted entities

### DIFF
--- a/browser-plugins/firefox/data/addin.js
+++ b/browser-plugins/firefox/data/addin.js
@@ -66,7 +66,7 @@ exports.init = function () {
   pluginState.onAddInModuleEvent('page-content-script-attached-target-addin', function (data) {
     //Listen for panelHTML requests from the injected page
     pluginState.addContentScriptEventHandler(data.contentScriptKey,'requestPanelHtml-target-addin', function () {
-        pluginState.getDomainList(function (divHtml){
+        pluginState.getExtractedEntities(pluginState.trailsUrlsUrl, function (divHtml){
             if (divHtml) {
                 var messageToContentScript = {};
                 messageToContentScript.panelHtml = divHtml;

--- a/browser-plugins/firefox/data/addin.js
+++ b/browser-plugins/firefox/data/addin.js
@@ -64,6 +64,12 @@ exports.init = function () {
   });
   //Here we listen for when the content scripts is fired up and ready.
   pluginState.onAddInModuleEvent('page-content-script-attached-target-addin', function (data) {
+    pluginState.addContentScriptEventHandler(data.contentScriptKey,'requestPanelHtml-target-addin', function () {
+      var messageToContentScript = {};
+      messageToContentScript.panelHtml = getPanelHtml();
+      pluginState.postEventToContentScript(data.contentScriptKey, 'send-panel', messageToContentScript);
+    });
+
     pluginState.addContentScriptEventHandler(data.contentScriptKey, 'send-css-urls-target-addin', function (scriptData) {
       pluginState.postEventToContentScript(scriptData.contentScriptKey, 'load-css-urls-target-content-script',
         {
@@ -72,6 +78,7 @@ exports.init = function () {
           ]
         });
     });
+
     pluginState.addContentScriptEventHandler(data.contentScriptKey, 'zipped-html-body-target-addin', function (pageContents) {
       //TODO: Work out some scraper eventing so we don't do the DOM operation if we're not trailing.
       //This will work for now though.
@@ -95,6 +102,7 @@ exports.init = function () {
        var html = zip.file('zipped-html-body.zip').asText();*/
     });
   });
+
   //Here we listen for when the DD content script is fired up and ready.
   pluginState.onAddInModuleEvent('page-datawake-depot-content-script-attached-target-addin', function (data) {
     pluginState.addDatawakeDepotContentScriptEventHandler('logout-success-target-plugin', function (user) {
@@ -153,6 +161,13 @@ exports.init = function () {
     postPluginStateToToolBar();
   });
 };
+
+function getPanelHtml(){
+    var d = new Date();
+    var panelHtml = '<div id="timer">' + d.toLocaleTimeString() + '</div>';
+    return panelHtml;
+}
+
 function logoutSuccessfulHandler(tellToolBar) {
   pluginState.reset();
   pluginState.postEventToAddInModule('logged-out-target-context-menu');

--- a/browser-plugins/firefox/data/addin.js
+++ b/browser-plugins/firefox/data/addin.js
@@ -26,6 +26,10 @@ exports.init = function () {
           //login tabs. Not today.
           pluginState.postEventToDatawakeDepotContentScript('logout-target-content-script');
           break;
+        case 'toggle-panel':
+          var activeTabId = tabs.activeTab.id;
+          pluginState.postEventToContentScript(activeTabId, 'send-toggle-datawake-panel');
+          break;
         case 'set-trailing-active':
           pluginState.trailingActive = msg.data;
           break;
@@ -158,7 +162,7 @@ function logoutSuccessfulHandler(tellToolBar) {
   }
   var msg = {
     type: 'logout-success-target-toolbar-frame'
-  }
+  };
   pluginState.postMessageToToolBar(msg);
 }
 function loginSuccessfulHandler(user) {

--- a/browser-plugins/firefox/data/addin.js
+++ b/browser-plugins/firefox/data/addin.js
@@ -66,7 +66,7 @@ exports.init = function () {
   pluginState.onAddInModuleEvent('page-content-script-attached-target-addin', function (data) {
     //Listen for panelHTML requests from the injected page
     pluginState.addContentScriptEventHandler(data.contentScriptKey,'requestPanelHtml-target-addin', function () {
-        pluginState.getExtractedEntities(pluginState.trailsUrlsUrl, function (divHtml){
+        pluginState.getExtractedEntities(data.pageUrl, function (divHtml){
             if (divHtml) {
                 var messageToContentScript = {};
                 messageToContentScript.panelHtml = divHtml;

--- a/browser-plugins/firefox/data/addin.js
+++ b/browser-plugins/firefox/data/addin.js
@@ -64,6 +64,7 @@ exports.init = function () {
   });
   //Here we listen for when the content scripts is fired up and ready.
   pluginState.onAddInModuleEvent('page-content-script-attached-target-addin', function (data) {
+    //Listen for panelHTML requests from the injected page
     pluginState.addContentScriptEventHandler(data.contentScriptKey,'requestPanelHtml-target-addin', function () {
       var messageToContentScript = {};
       messageToContentScript.panelHtml = getPanelHtml();
@@ -163,8 +164,9 @@ exports.init = function () {
 };
 
 function getPanelHtml(){
-    var d = new Date();
-    var panelHtml = '<div id="timer">' + d.toLocaleTimeString() + '</div>';
+    //var d = new Date();
+    //var panelHtml = '<div id="timer">' + d.toLocaleTimeString() + '</div>';
+    pluginState.getDomainList();
     return panelHtml;
 }
 

--- a/browser-plugins/firefox/data/addin.js
+++ b/browser-plugins/firefox/data/addin.js
@@ -66,9 +66,13 @@ exports.init = function () {
   pluginState.onAddInModuleEvent('page-content-script-attached-target-addin', function (data) {
     //Listen for panelHTML requests from the injected page
     pluginState.addContentScriptEventHandler(data.contentScriptKey,'requestPanelHtml-target-addin', function () {
-      var messageToContentScript = {};
-      messageToContentScript.panelHtml = getPanelHtml();
-      pluginState.postEventToContentScript(data.contentScriptKey, 'send-panel', messageToContentScript);
+        pluginState.getDomainList(function (divHtml){
+            if (divHtml) {
+                var messageToContentScript = {};
+                messageToContentScript.panelHtml = divHtml;
+                pluginState.postEventToContentScript(data.contentScriptKey, 'send-panel', messageToContentScript);
+            }
+        });
     });
 
     pluginState.addContentScriptEventHandler(data.contentScriptKey, 'send-css-urls-target-addin', function (scriptData) {
@@ -162,13 +166,6 @@ exports.init = function () {
     postPluginStateToToolBar();
   });
 };
-
-function getPanelHtml(){
-    //var d = new Date();
-    //var panelHtml = '<div id="timer">' + d.toLocaleTimeString() + '</div>';
-    pluginState.getDomainList();
-    return panelHtml;
-}
 
 function logoutSuccessfulHandler(tellToolBar) {
   pluginState.reset();

--- a/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
+++ b/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
@@ -12,6 +12,7 @@ div#datawake-right-panel {
     color: #dddddd;
     background-color: #252644;
     background: #252644;
+    z-index:10000;
 }
 
 div#datawake-site {

--- a/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
+++ b/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
@@ -1,6 +1,6 @@
 .highlight {
     color: #dddddd;
-    background-color: #004400;
+    background-color: #252644;
 }
 
 div#datawake-right-panel {
@@ -9,7 +9,9 @@ div#datawake-right-panel {
     right: 0;
     bottom: 0;
     width: 300px;
-    background: green;
+    color: #dddddd;
+    background-color: #252644;
+    background: #252644;
 }
 
 div#datawake-site {

--- a/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
+++ b/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
@@ -7,7 +7,6 @@ div#datawake-right-panel {
     position: absolute;
     top: 0;
     right: 0;
-    bottom: 0;
     width: 300px;
     color: #dddddd;
     background-color: #252644;
@@ -19,9 +18,25 @@ div#datawake-right-panel {
     width: 100%;
 }
 
-.DWD_table{
-    width:100%;
+.DWD_table {
+    border-collapse: collapse;
+    width: 100%;
 }
+
+.DWD_td {
+    text-align: left;
+    padding: 8px;
+}
+
+.DWD_tr:nth-child(even){background-color: #f2f2f2}
+
+.DWD_th {
+    background-color: #3176af;
+    color: white;
+    text-align: left;
+    padding: 8px;
+}
+
 
 div#datawake-site {
     margin-right: 300px;

--- a/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
+++ b/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
@@ -8,9 +8,9 @@ div#datawake-right-panel {
     top: 0;
     right: 0;
     width: 300px;
-    color: #dddddd;
-    background-color: #252644;
-    background: #252644;
+    color: black;
+    background-color: white;
+    background: white;
     z-index:10000;
 }
 
@@ -37,6 +37,10 @@ div#datawake-right-panel {
     padding: 8px;
 }
 
+.DWD_table_container{
+    max-height: 500px;
+    overflow: scroll;
+}
 
 div#datawake-site {
     margin-right: 300px;

--- a/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
+++ b/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
@@ -54,3 +54,8 @@ div#datawake-right-panel {
 div#datawake-site {
     margin-right: 300px;
 }
+
+.DWD_h1{
+    background-color: dodgerblue;
+    text-align: center
+}

--- a/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
+++ b/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
@@ -4,7 +4,7 @@
 }
 
 div#datawake-right-panel {
-    position: fixed;
+    position: absolute;
     top: 0;
     right: 0;
     bottom: 0;
@@ -13,6 +13,14 @@ div#datawake-right-panel {
     background-color: #252644;
     background: #252644;
     z-index:10000;
+}
+
+.DWD_widget{
+    width: 100%;
+}
+
+.DWD_table{
+    width:100%;
 }
 
 div#datawake-site {

--- a/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
+++ b/browser-plugins/firefox/data/injectedPageCSS/datawake-analysis.css
@@ -5,12 +5,15 @@
 
 div#datawake-right-panel {
     position: absolute;
+    border-radius:5px;
+    border: 2px solid black;
     top: 0;
+    bottom: 0;
     right: 0;
     width: 300px;
-    color: black;
-    background-color: white;
-    background: white;
+    color: white;
+    background-color: skyblue;
+    background: steelblue;
     z-index:10000;
 }
 
@@ -26,15 +29,21 @@ div#datawake-right-panel {
 .DWD_td {
     text-align: left;
     padding: 8px;
+    font-size: .65em;
 }
 
-.DWD_tr:nth-child(even){background-color: #f2f2f2}
+
+.DWD_tr:nth-child(odd){
+    background-color: white;
+    color: black
+}
 
 .DWD_th {
-    background-color: #3176af;
+    background-color: lightslategray;
     color: white;
     text-align: left;
     padding: 8px;
+    font-size: .8em;
 }
 
 .DWD_table_container{

--- a/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
+++ b/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
@@ -4,14 +4,15 @@
 //scripts.
 var myContentScriptKey = null;
 var myVar = null;
+var iInterval = 2500;
 
 //Show panel after each page load
 $(document).ready(function () {
     showPanel();
     //Now populate it
-    rewritePanel('<body><div id="timer">initializing</div></body>');
+    rewritePanel('<body><div class="DWD_widget" id="timer">&nbsp;&nbsp;initializing...</div></body>');
     //Now start a poller to keep repopulating it as long as they're on this page
-    myVar = setInterval(panelTimer, 5000);
+    myVar = setInterval(panelTimer, iInterval);
 });
 
 //Load all CSS urls
@@ -33,7 +34,7 @@ self.port.on('load-css-urls-target-content-script', function (data) {
 
 function showPanel(){
     if ($('#datawake-right-panel').length === 0){
-        var datawakePanel = '<div id="datawake-right-panel"><div id="widgetOne"></div></div>';
+        var datawakePanel = '<div class="DWD_widget" id="datawake-right-panel"><div id="widgetOne"></div></divDWD_widget>';
         $('body').append(datawakePanel);
     }
 }
@@ -72,7 +73,7 @@ self.port.on('send-toggle-datawake-panel', function () {
     if ($('#datawake-right-panel').length === 0) {
         var datawakePanel = '<div class="datawake-right-panel" id="datawake-right-panel"></div>';
         $('body').append(datawakePanel);
-        myVar = setInterval(panelTimer, 5000);
+        myVar = setInterval(panelTimer, iInterval);
     }else{
         $("#datawake-right-panel").remove();
         clearInterval(myVar);

--- a/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
+++ b/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
@@ -9,9 +9,9 @@ var myVar = null;
 $(document).ready(function () {
     showPanel();
     //Now populate it
-    rewritePanelHtml('<body><h1>Hey it works</h1><div id="timer">initialized</div></body>');
+    rewritePanel('<body><h1>Panel Activated</h1><div id="timer">initializing</div></body>');
     //Now start a poller to keep repopulating it as long as they're on this page
-    myVar = setInterval(myTimer, 5000);
+    myVar = setInterval(panelTimer, 10000);
 });
 
 //Load all CSS urls
@@ -33,23 +33,31 @@ self.port.on('load-css-urls-target-content-script', function (data) {
 
 function showPanel(){
     if ($('#datawake-right-panel').length === 0){
-        var datawakePanel = '<div id="datawake-right-panel"></div>';
+        var datawakePanel = '<div id="datawake-right-panel"><div id="initialDiv"></div></div>';
         $('body').append(datawakePanel);
     }
 }
 
-function rewritePanelHtml(html){
+function rewritePanel(html){
   $('#datawake-right-panel').html(html);
 }
 
-function myTimer(){
-    var d = new Date();
-    rewritePanelHtml('<body><h1>updated</h1><div id="timer">' + d.toLocaleTimeString() + '</div></body>');
+function rewritePanelDiv(div,html){
+    $('#datawake-right-panel').append(html);
 }
+
+function panelTimer(){
+    self.port.emit('requestPanelHtml-target-addin', {contentScriptKey: myContentScriptKey});
+}
+
+//Populate panel
+self.port.on('send-panel', function (data) {
+    rewritePanelDiv("#widgetOne",data.panelHtml);
+});
 
 //Test panel populate
 self.port.on('test-datawake-panel-content', function (data) {
-  rewritePanelHtml('This is the test text.');
+  rewritePanel('This is the test text.');
 });
 
 //Toggle side panel
@@ -57,10 +65,17 @@ self.port.on('send-toggle-datawake-panel', function () {
     if ($('#datawake-right-panel').length === 0) {
         var datawakePanel = '<div id="datawake-right-panel"></div>';
         $('body').append(datawakePanel);
-        myVar = setInterval(myTimer, 5000);
+        myVar = setInterval(panelTimer, 5000);
     }else{
         $("#datawake-right-panel").remove();
         clearInterval(myVar);
+    }
+});
+
+//Populate side panel
+self.port.on('send-panel', function (data) {
+    if ($('#datawake-right-panel').length === 0) {
+        rewritePanel(data.panelHtml);
     }
 });
 

--- a/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
+++ b/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
@@ -60,7 +60,7 @@ self.port.on('send-toggle-datawake-panel', function () {
         myVar = setInterval(myTimer, 5000);
     }else{
         $("#datawake-right-panel").remove();
-        myVar = null;
+        clearInterval(myVar);
     }
 });
 

--- a/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
+++ b/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
@@ -9,9 +9,9 @@ var myVar = null;
 $(document).ready(function () {
     showPanel();
     //Now populate it
-    rewritePanel('<body><h1>Panel Activated</h1><div id="timer">initializing</div></body>');
+    rewritePanel('<body><div id="timer">initializing</div></body>');
     //Now start a poller to keep repopulating it as long as they're on this page
-    myVar = setInterval(panelTimer, 10000);
+    myVar = setInterval(panelTimer, 5000);
 });
 
 //Load all CSS urls
@@ -33,7 +33,7 @@ self.port.on('load-css-urls-target-content-script', function (data) {
 
 function showPanel(){
     if ($('#datawake-right-panel').length === 0){
-        var datawakePanel = '<div id="datawake-right-panel"><div id="initialDiv"></div></div>';
+        var datawakePanel = '<div id="datawake-right-panel"><div id="widgetOne"></div></div>';
         $('body').append(datawakePanel);
     }
 }
@@ -43,16 +43,23 @@ function rewritePanel(html){
 }
 
 function rewritePanelDiv(div,html){
-    $('#datawake-right-panel').append(html);
+    $(div).remove();
+    $("#datawake-right-panel").append(html);
 }
 
 function panelTimer(){
     self.port.emit('requestPanelHtml-target-addin', {contentScriptKey: myContentScriptKey});
 }
 
+function buildPanelContents(data){
+    var panelHtml = data.panelHtml;
+    $('#timer').remove();
+    rewritePanelDiv("#widgetOne", panelHtml);
+}
+
 //Populate panel
 self.port.on('send-panel', function (data) {
-    rewritePanelDiv("#widgetOne",data.panelHtml);
+    buildPanelContents(data);
 });
 
 //Test panel populate

--- a/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
+++ b/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
@@ -63,7 +63,7 @@ self.port.on('test-datawake-panel-content', function (data) {
 //Toggle side panel
 self.port.on('send-toggle-datawake-panel', function () {
     if ($('#datawake-right-panel').length === 0) {
-        var datawakePanel = '<div id="datawake-right-panel"></div>';
+        var datawakePanel = '<div class="datawake-right-panel" id="datawake-right-panel"></div>';
         $('body').append(datawakePanel);
         myVar = setInterval(panelTimer, 5000);
     }else{

--- a/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
+++ b/browser-plugins/firefox/data/injectedPageScripts/datawake-analysis.js
@@ -8,11 +8,11 @@ var iInterval = 2500;
 
 //Show panel after each page load
 $(document).ready(function () {
-    showPanel();
+    //showPanel();
     //Now populate it
-    rewritePanel('<body><div class="DWD_widget" id="timer">&nbsp;&nbsp;initializing...</div></body>');
+    //rewritePanel('<body><div class="DWD_widget" id="timer">&nbsp;&nbsp;initializing...</div></body>');
     //Now start a poller to keep repopulating it as long as they're on this page
-    myVar = setInterval(panelTimer, iInterval);
+    //myVar = setInterval(panelTimer, iInterval);
 });
 
 //Load all CSS urls
@@ -32,12 +32,12 @@ self.port.on('load-css-urls-target-content-script', function (data) {
   });
 });
 
-function showPanel(){
-    if ($('#datawake-right-panel').length === 0){
-        var datawakePanel = '<div class="DWD_widget" id="datawake-right-panel"><div id="widgetOne"></div></divDWD_widget>';
-        $('body').append(datawakePanel);
-    }
-}
+//function showPanel(){
+//    if ($('#datawake-right-panel').length === 0){
+//        var datawakePanel = '<div class="DWD_widget" id="datawake-right-panel"><div id="widgetOne">&nbsp;&nbsp;initializing...</div></divDWD_widget>';
+//        $('body').append(datawakePanel);
+//    }
+//}
 
 function rewritePanel(html){
   $('#datawake-right-panel').html(html);
@@ -71,7 +71,7 @@ self.port.on('test-datawake-panel-content', function (data) {
 //Toggle side panel
 self.port.on('send-toggle-datawake-panel', function () {
     if ($('#datawake-right-panel').length === 0) {
-        var datawakePanel = '<div class="datawake-right-panel" id="datawake-right-panel"></div>';
+        var datawakePanel = '<div class="DWD_widget" id="datawake-right-panel"><div id="widgetOne">&nbsp;&nbsp;initializing...</div></divDWD_widget>';
         $('body').append(datawakePanel);
         myVar = setInterval(panelTimer, iInterval);
     }else{

--- a/browser-plugins/firefox/data/pageMods.js
+++ b/browser-plugins/firefox/data/pageMods.js
@@ -4,7 +4,7 @@ exports.init = function () {
   try {
     pageMod.PageMod({
       include: '*',
-      //exclude: pluginState.pageModDatawakeDepotIncludeFilter,
+      exclude: pluginState.pageModDatawakeDepotIncludeFilter, // this prevents Depot urls from being trailed and panel
       contentScriptFile: [
         './vendor/jszip/jszip.min.js',
         './vendor/jquery/jquery-2.1.4.min.js',
@@ -22,7 +22,7 @@ exports.init = function () {
   try {
     pageMod.PageMod({
       include: pluginState.pageModDatawakeDepotIncludeFilter,
-      //exclude: '*',
+      exclude: '*', // this prevents Depot urls from being trailed and panel
       contentScriptFile: './injectedPageScripts/datawake-depot.js',
       attachTo: ['existing', 'top', 'frame'],
       onAttach: pluginState.onDatawakeDepotContentScriptAttach

--- a/browser-plugins/firefox/data/pageMods.js
+++ b/browser-plugins/firefox/data/pageMods.js
@@ -4,7 +4,7 @@ exports.init = function () {
   try {
     pageMod.PageMod({
       include: '*',
-      exclude: pluginState.pageModDatawakeDepotIncludeFilter, // this prevents Depot urls from being trailed and panel
+      //exclude: pluginState.pageModDatawakeDepotIncludeFilter, // this prevents Depot urls from being trailed and panel
       contentScriptFile: [
         './vendor/jszip/jszip.min.js',
         './vendor/jquery/jquery-2.1.4.min.js',
@@ -22,7 +22,7 @@ exports.init = function () {
   try {
     pageMod.PageMod({
       include: pluginState.pageModDatawakeDepotIncludeFilter,
-      exclude: '*', // this prevents Depot urls from being trailed and panel
+      //exclude: '*', // this prevents Depot urls from being trailed and panel
       contentScriptFile: './injectedPageScripts/datawake-depot.js',
       attachTo: ['existing', 'top', 'frame'],
       onAttach: pluginState.onDatawakeDepotContentScriptAttach

--- a/browser-plugins/firefox/data/pluginState.js
+++ b/browser-plugins/firefox/data/pluginState.js
@@ -55,7 +55,7 @@ var PluginState = function () {
   me.getDomainList = function (cb) {
       var url = me.domainList;
       me.restSimpleGet(url, function (res) {
-          cb(res.json);
+          cb(res.text);
       });
   };
 

--- a/browser-plugins/firefox/data/pluginState.js
+++ b/browser-plugins/firefox/data/pluginState.js
@@ -18,6 +18,7 @@ var PluginState = function () {
   me.trailsUrlsUrl = '/api/dwTrailUrls';
   me.domainItemsUrl = '/api/dwDomainItems';
   me.domainList = '/widget/get-domain-list';
+  me.trailExtractedEntities = '/widget/get-url-entities'
   me.trailingActive = false;
   me.toolbarFrameSource = null;
   me.toolbarFrameOrigin = null;
@@ -34,7 +35,9 @@ var PluginState = function () {
   };
   me.restGet = function (url, queryStringObj, callback) {
     queryStringObj = queryStringObj || {};
-    queryStringObj.access_token = me.loggedInUser.accessToken;
+    if(me.loggedInUser) {
+        queryStringObj.access_token = me.loggedInUser.accessToken;
+    }
     var queryStringJson = me.convertObjToQueryString(queryStringObj);
     url = me.loginUrl + url;
     url += '?' + queryStringJson;
@@ -57,6 +60,20 @@ var PluginState = function () {
       me.restSimpleGet(url, function (res) {
           cb(res.text);
       });
+  };
+
+  me.getExtractedEntities = function (trailUrl, cb) {
+    var url = me.trailExtractedEntities;
+    var filter = {
+      //where: {
+      //  //dwTrailUrlId: '5668f428df91e9e370d0921e'
+      //  //replace this with
+      //  //dwTrailUrl: url
+      //}
+    };
+    me.restGet(url, filter, function (res) {
+      cb(res.text);
+    });
   };
 
   me.getDomainItemsForCurrentDomain = function (cb) {
@@ -160,7 +177,7 @@ var PluginState = function () {
     me.currentDomainList = [];
     me.currentTrail = null;
     me.currentTrailList = [];
-  }
+  };
   me.generateUUID = function () {
     var d = new Date().getTime();
     var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {

--- a/browser-plugins/firefox/data/pluginState.js
+++ b/browser-plugins/firefox/data/pluginState.js
@@ -65,11 +65,7 @@ var PluginState = function () {
   me.getExtractedEntities = function (trailUrl, cb) {
     var url = me.trailExtractedEntities;
     var filter = {
-      //where: {
-      //  //dwTrailUrlId: '5668f428df91e9e370d0921e'
-      //  //replace this with
-      //  //dwTrailUrl: url
-      //}
+        "trailUrl":trailUrl
     };
     me.restGet(url, filter, function (res) {
       cb(res.text);
@@ -152,7 +148,7 @@ var PluginState = function () {
     var newContentScriptKey = worker.tab.id;
     me.contentScriptHandles[newContentScriptKey] = worker;
     me.postEventToAddInModule('page-content-script-attached-target-addin',
-      {contentScriptKey: newContentScriptKey});
+      {contentScriptKey: newContentScriptKey,pageUrl: worker.tab.url});
     me.postEventToContentScript(newContentScriptKey, 'page-attached-target-content-script',
       {contentScriptKey: newContentScriptKey});
   }

--- a/browser-plugins/firefox/data/pluginState.js
+++ b/browser-plugins/firefox/data/pluginState.js
@@ -17,6 +17,7 @@ var PluginState = function () {
   me.trailsUrl = '/api/dwTrails';
   me.trailsUrlsUrl = '/api/dwTrailUrls';
   me.domainItemsUrl = '/api/dwDomainItems';
+  me.domainList = '/widget/get-domain-list';
   me.trailingActive = false;
   me.toolbarFrameSource = null;
   me.toolbarFrameOrigin = null;
@@ -42,6 +43,22 @@ var PluginState = function () {
       onComplete: callback
     }).get();
   };
+
+  me.restSimpleGet = function (url, callback) {
+      url = me.loginUrl + url;
+      Request({
+          url: url,
+          onComplete: callback
+      }).get();
+  };
+
+  me.getDomainList = function (cb) {
+      var url = me.domainList;
+      me.restSimpleGet(url, function (res) {
+          cb(res.json);
+      });
+  };
+
   me.getDomainItemsForCurrentDomain = function (cb) {
     var url = me.domainItemsUrl;
     var filter = {

--- a/browser-plugins/firefox/data/toolbarFrame.html
+++ b/browser-plugins/firefox/data/toolbarFrame.html
@@ -70,12 +70,18 @@
            class="btn btn-sm btn-success btn-block disabled"
            onclick="toggleTrailing()">Start</a>
       </div>
-      <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2"
+      <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1"
            style="padding-left:2px;padding-right:4px;">
         <a id="loginButton"
            role="button"
            class="btn btn-sm btn-success btn-block"
            onclick="toggleLogin()">Login</a>
+      </div>
+      <div>
+        <a id="toggleButton"
+           role="button"
+           class="btn btn-sm btn-primary"
+           onclick="togglePanel()">Toggle</a>
       </div>
     </div>
   </form>

--- a/browser-plugins/firefox/data/toolbarFrame.js
+++ b/browser-plugins/firefox/data/toolbarFrame.js
@@ -111,6 +111,10 @@ function toggleLogin() {
     postMessageToAddin({action: 'login'});
   }
 }
+function togglePanel(){
+    postMessageToAddin({action: 'toggle-panel'});
+}
+
 //
 //ComboBox selection changed handlers
 //

--- a/client/app/modules/dwTrailUrls/config/trailUrls.routes.js
+++ b/client/app/modules/dwTrailUrls/config/trailUrls.routes.js
@@ -6,20 +6,20 @@ app.config(function($stateProvider) {
         abstract: true,
         url: '/dwTrailUrls',
         templateUrl: 'modules/dwTrailUrls/views/main'
-    }).state('app.dwTrailUrls.list', {
-        url: '',
-        templateUrl: 'modules/dwTrailUrls/views/list',
-        controller: 'TrailUrlsCtrl'
     }).state('app.dwTrailUrls.add', {
-        url: '/add',
+        url: '/add/:trailId',
         templateUrl: 'modules/dwTrailUrls/views/form',
         controller: 'TrailUrlsCtrl'
+    }).state('app.dwTrailUrls.list', {
+        url: '/list/:trailId',
+        templateUrl: 'modules/dwTrailUrls/views/list',
+        controller: 'TrailUrlsCtrl'
     }).state('app.dwTrailUrls.edit', {
-        url: '/:id/edit',
+        url: 'edit/:id/:trailId',
         templateUrl: 'modules/dwTrailUrls/views/form',
         controller: 'TrailUrlsCtrl'
     }).state('app.dwTrailUrls.view', {
-        url: '/:id',
+        url: '/view/:id',
         templateUrl: 'modules/dwTrailUrls/views/view',
         controller: 'TrailUrlsCtrl'
     });

--- a/client/app/modules/dwTrailUrls/controllers/trailUrls.ctrl.js
+++ b/client/app/modules/dwTrailUrls/controllers/trailUrls.ctrl.js
@@ -3,144 +3,145 @@ var app = angular.module('com.module.dwTrailUrls');
 
 app.controller('TrailUrlsCtrl', function($scope, $state, $stateParams, $window, DwCrawlType, DwTrail, DwTrailUrl, TrailUrlsService, gettextCatalog, AppAuth) {
 
-  //Put the currentUser in $scope for convenience
-  $scope.currentUser = AppAuth.currentUser;
-  $scope.trails = [];
-  $scope.crawlTypes = [];
-
-  $scope.trailUrl = {};
-  $scope.formFields = [{
-    key: 'id',
-    type: 'input',
-    templateOptions: {
-      label: gettextCatalog.getString('id'),
-      disabled: true
-    }
-  }, {
-      key: 'dwTrailId',
-      type: 'select',
-      templateOptions: {
-          label: gettextCatalog.getString('Trail'),
-          options: $scope.trails,
-          valueProp: 'id',
-          labelProp: 'name',
-          required: true,
-          disabled: false
-      }
-  },{
-    key: 'url',
-    type: 'input',
-    templateOptions: {
-      label: gettextCatalog.getString('Url'),
-      required: true
-    }
-  },{
-      key: 'scrapedContent',
-      type: 'textarea',
-      templateOptions: {
-          label: gettextCatalog.getString('Scraped Content')
-      }
-  }, {
-    key: 'dwCrawlTypeId',
-    type: 'select',
-    templateOptions: {
-      label: gettextCatalog.getString('CrawlType'),
-      options: $scope.crawlTypes,
-      valueProp: 'id',
-      labelProp: 'name',
-      required: true,
-      disabled: false
-      }
-  }, {
-    key: 'timestamp',
-    type: 'input',
-    templateOptions: {
-      label: gettextCatalog.getString('Timestamp'),
-      required: false,
-      disabled: true
-    }
-  }, {
-    key: 'comments',
-    type: 'input',
-    templateOptions: {
-      label: gettextCatalog.getString('Comments'),
-      disabled: false,
-      required: false
-    }
-  }];
-
-  $scope.delete = function(id) {
-    TrailUrlsService.deleteTrailUrl(id, function() {
-      $scope.safeDisplayedtrailUrls = TrailUrlsService.getTrailUrls();
-      $state.go('^.list');
-    });
-  };
-
-  $scope.onSubmit = function() {
-    TrailUrlsService.upsertTrailUrl($scope.trailUrl, function() {
-      $scope.safeDisplayedtrailUrls = TrailUrlsService.getTrailUrls();
-      $state.go('^.list');
-    });
-  };
-
-  $scope.openUrl = function(trailUrl){
-      $window.open(trailUrl.url);
-  }
-
-  $scope.loading = true;
-  DwTrailUrl.find({filter: {include: ['trail','crawlType','urlExtractions']}}).$promise
-      .then(function (allTrailUrls) {
-        $scope.safeDisplayedtrailUrls = allTrailUrls;
-        $scope.displayedTrailUrls = [].concat($scope.safeDisplayedtrailUrls);
-      })
-      .catch(function (err) {
-        console.log(err);
-      })
-      .then(function () {
-        $scope.loading = false;
-      }
-  );
-
-  DwCrawlType.find({filter: {include: []}}).$promise
-      .then(function (allCrawlTypes) {
-          for (var i = 0; i < allCrawlTypes.length; ++i) {
-              $scope.crawlTypes.push({
-                  value: allCrawlTypes[i].name,
-                  name: allCrawlTypes[i].name + " - " + allCrawlTypes[i].description,
-                  id: allCrawlTypes[i].id
-              });
-          }
-      })
-      .catch(function (err) {
-          console.log(err);
-      })
-      .then(function () {
-      }
-  );
-
-  DwTrail.find({filter: {include: []}}).$promise
-      .then(function (allTrails) {
-          for (var i = 0; i < allTrails.length; ++i) {
-              $scope.trails.push({
-                  value: allTrails[i].name,
-                  name: allTrails[i].name + " - " + allTrails[i].description,
-                  id: allTrails[i].id
-              });
-          }
-      })
-      .catch(function (err) {
-          console.log(err);
-      })
-      .then(function () {
-      }
-  );
-
-  if ($stateParams.id) {
-    TrailUrlsService.getTrailUrl($stateParams.id).$promise.then(function(result){
-      $scope.trailUrl = result;})
-  } else {
+    //Put the currentUser in $scope for convenience
+    $scope.currentUser = AppAuth.currentUser;
+    $scope.trails = [];
+    $scope.crawlTypes = [];
+    $scope.currentTrailId = '';
     $scope.trailUrl = {};
-  }
+    $scope.formFields = [{
+        key: 'id',
+        type: 'input',
+        templateOptions: {
+            label: gettextCatalog.getString('id'),
+            disabled: true
+        }
+    }, {
+        key: 'dwTrailId',
+        type: 'select',
+        templateOptions: {
+            label: gettextCatalog.getString('Trail'),
+            options: $scope.trails,
+            valueProp: 'id',
+            labelProp: 'name',
+            required: true,
+            disabled: false
+        }
+    },{
+        key: 'url',
+        type: 'input',
+        templateOptions: {
+            label: gettextCatalog.getString('Url'),
+            required: true
+        }
+    },{
+        key: 'scrapedContent',
+        type: 'textarea',
+        templateOptions: {
+            label: gettextCatalog.getString('Scraped Content')
+        }
+    }, {
+        key: 'dwCrawlTypeId',
+        type: 'select',
+        templateOptions: {
+            label: gettextCatalog.getString('CrawlType'),
+            options: $scope.crawlTypes,
+            valueProp: 'id',
+            labelProp: 'name',
+            required: true,
+            disabled: false
+        }
+    }, {
+        key: 'timestamp',
+        type: 'input',
+        templateOptions: {
+            label: gettextCatalog.getString('Timestamp'),
+            required: false,
+            disabled: true
+        }
+    }, {
+        key: 'comments',
+        type: 'input',
+        templateOptions: {
+            label: gettextCatalog.getString('Comments'),
+            disabled: false,
+            required: false
+        }
+    }];
 
+    $scope.delete = function(id) {
+        TrailUrlsService.deleteTrailUrl(id, function() {
+            $scope.safeDisplayedtrailUrls = TrailUrlsService.getTrailUrls();
+            $state.go('^.list');
+        });
+    };
+
+    $scope.onSubmit = function() {
+        TrailUrlsService.upsertTrailUrl($scope.trailUrl, function() {
+            $scope.safeDisplayedtrailUrls = TrailUrlsService.getTrailUrls();
+            $state.go('^.list');
+        });
+    };
+
+    $scope.openUrl = function(trailUrl){
+        $window.open(trailUrl.url);
+    };
+
+    DwCrawlType.find({filter: {include: []}}).$promise
+        .then(function (allCrawlTypes) {
+            for (var i = 0; i < allCrawlTypes.length; ++i) {
+                $scope.crawlTypes.push({
+                    value: allCrawlTypes[i].name,
+                    name: allCrawlTypes[i].name + " - " + allCrawlTypes[i].description,
+                    id: allCrawlTypes[i].id
+                });
+            }
+        })
+        .catch(function (err) {
+            console.log(err);
+        })
+        .then(function () {
+        }
+    );
+
+    DwTrail.find({filter: {include: []}}).$promise
+        .then(function (allTrails) {
+            for (var i = 0; i < allTrails.length; ++i) {
+                $scope.trails.push({
+                    value: allTrails[i].name,
+                    name: allTrails[i].name + " - " + allTrails[i].description,
+                    id: allTrails[i].id
+                });
+            }
+        })
+        .catch(function (err) {
+            console.log(err);
+        })
+        .then(function () {
+        }
+    );
+
+    if ($stateParams.id) {
+        TrailUrlsService.getTrailUrl($stateParams.id).$promise.then(function(result) {
+            $scope.currentTrailId = $stateParams.trailId;
+            $scope.trailUrl = result;
+            $scope.safeDisplayedTrails = {};
+            $scope.displayedTrailUrls = {};
+        })
+    } else if ($stateParams.trailId){
+        TrailUrlsService.getFilteredTrailUrls($stateParams.trailId).$promise.then(function(result){
+            $scope.currentTrailId = $stateParams.trailId;
+            $scope.trailUrl = {};
+            $scope.safeDisplayedtrailUrls = result;
+            $scope.displayedTrailUrls = [].concat($scope.safeDisplayedtrailUrls);
+        })
+    } else {
+        TrailUrlsService.getTrailUrls().$promise.then(function(result){
+            $scope.currentTrailId = '';
+            $scope.trailUrl = {};
+            $scope.safeDisplayedtrailUrls = result;
+            $scope.displayedTrailUrls = [].concat($scope.safeDisplayedtrailUrls);
+        });
+    }
 });
 

--- a/client/app/modules/dwTrailUrls/controllers/trailUrls.ctrl.js
+++ b/client/app/modules/dwTrailUrls/controllers/trailUrls.ctrl.js
@@ -87,6 +87,8 @@ app.controller('TrailUrlsCtrl', function($scope, $state, $stateParams, $window, 
         $window.open(trailUrl.url);
     };
 
+    $scope.loading = true;
+
     DwCrawlType.find({filter: {include: []}}).$promise
         .then(function (allCrawlTypes) {
             for (var i = 0; i < allCrawlTypes.length; ++i) {
@@ -127,6 +129,7 @@ app.controller('TrailUrlsCtrl', function($scope, $state, $stateParams, $window, 
             $scope.trailUrl = result;
             $scope.safeDisplayedTrails = {};
             $scope.displayedTrailUrls = {};
+            $scope.loading = false;
         })
     } else if ($stateParams.trailId){
         TrailUrlsService.getFilteredTrailUrls($stateParams.trailId).$promise.then(function(result){
@@ -134,6 +137,7 @@ app.controller('TrailUrlsCtrl', function($scope, $state, $stateParams, $window, 
             $scope.trailUrl = {};
             $scope.safeDisplayedtrailUrls = result;
             $scope.displayedTrailUrls = [].concat($scope.safeDisplayedtrailUrls);
+            $scope.loading = false;
         })
     } else {
         TrailUrlsService.getTrailUrls().$promise.then(function(result){
@@ -141,6 +145,7 @@ app.controller('TrailUrlsCtrl', function($scope, $state, $stateParams, $window, 
             $scope.trailUrl = {};
             $scope.safeDisplayedtrailUrls = result;
             $scope.displayedTrailUrls = [].concat($scope.safeDisplayedtrailUrls);
+            $scope.loading = false;
         });
     }
 });

--- a/client/app/modules/dwTrailUrls/services/trailUrls.service.js
+++ b/client/app/modules/dwTrailUrls/services/trailUrls.service.js
@@ -4,7 +4,17 @@ var app = angular.module('com.module.dwTrailUrls');
 app.service('TrailUrlsService', ['$state', 'CoreService', 'DwTrail','DwTrailUrl','DwUrlExtraction', 'gettextCatalog', function($state, CoreService, DwTrail, DwTrailUrl,DwUrlExtraction, gettextCatalog) {
 
   this.getTrailUrls = function() {
-    return DwTrailUrl.find({filter: {include: ['trail','crawlType','urlExtractions']}});
+    var whereClause={
+        filter:{
+            order:"url DESC",
+            include:[
+                'trail',
+                'crawlType',
+                {relation:'urlExtractions',scope:{fields: ['id']}}
+            ]
+        }
+    };
+    return (DwTrailUrl.find(whereClause));
   };
 
   this.getTrailUrl = function(id) {
@@ -16,17 +26,17 @@ app.service('TrailUrlsService', ['$state', 'CoreService', 'DwTrail','DwTrailUrl'
   this.getFilteredTrailUrls = function(trailId) {
     var whereClause={
         filter:{
-            order:"timestamp DESC",
+            order:"url DESC",
             where:{
                 dwTrailId:trailId
             },
             include:[
                 'trail',
                 'crawlType',
-                'urlExtractions'
+                {relation:'urlExtractions',scope:{fields: ['id']}}
             ]
         }
-      };
+    };
     return (DwTrailUrl.find(whereClause));
   };
 

--- a/client/app/modules/dwTrailUrls/services/trailUrls.service.js
+++ b/client/app/modules/dwTrailUrls/services/trailUrls.service.js
@@ -13,6 +13,23 @@ app.service('TrailUrlsService', ['$state', 'CoreService', 'DwTrail','DwTrailUrl'
     });
   };
 
+  this.getFilteredTrailUrls = function(trailId) {
+    var whereClause={
+        filter:{
+            order:"timestamp DESC",
+            where:{
+                dwTrailId:trailId
+            },
+            include:[
+                'trail',
+                'crawlType',
+                'urlExtractions'
+            ]
+        }
+      };
+    return (DwTrailUrl.find(whereClause));
+  };
+
   this.upsertTrailUrl = function(trailUrl, cb) {
     DwTrailUrl.upsert(trailUrl, function() {
       CoreService.toastSuccess(gettextCatalog.getString(

--- a/client/app/modules/dwTrailUrls/views/form.jade
+++ b/client/app/modules/dwTrailUrls/views/form.jade
@@ -2,7 +2,7 @@
   .box-header
     span.box-title
       .input-group
-        a.btn.btn-default(translate, href='', ui-sref='^.list', style='float: left;')
+        a.btn.btn-default(translate, href='', ui-sref='^.list({trailId: currentTrailId })', style='float: left;')
           i.fa.fa-arrow-left &nbsp;Back to Trail URLs
     .box-tools.pull-right
       span.pull-right.btn-toolbar

--- a/client/app/modules/dwTrailUrls/views/list.jade
+++ b/client/app/modules/dwTrailUrls/views/list.jade
@@ -4,7 +4,7 @@
     table.table.table-striped(st-table='displayedTrailUrls', st-safe-src='safeDisplayedtrailUrls')
       thead
         tr
-          th(colspan="7")
+          th(colspan="6")
             input.input-sm.form-control(st-search='' type='search' placeholder='Search')
       thead
         tr
@@ -12,17 +12,20 @@
           th.col-sm-1.col-md-1.col-lg-1.td-center.text-nowrap # Extractions
           th.sortable.col-sm-1.col-md-1.col-lg-1(st-sort='trail.name') Trail
           th.sortable.col-sm-1.col-md-1.col-lg-1.text-nowrap(st-sort='dwCrawlTypeId') Crawl Type
-          th.sortable.col-sm-3.col-md-3.col-lg-3(st-sort='comments') Comments
+          th.sortable.col-sm-2.col-md-2.col-lg-2(st-sort='comments') Comments
           th.sortable.col-sm-2.col-md-2.col-lg-2(st-sort='timestamp') Timestamp
           th.col-sm-2.col-md-2.col-lg-2.td-center
-              a.btn.btn-sm.btn-success.glyphicon.glyphicon-plus.custom(ui-sref='^.add', ng-disabled='!currentUser.isAdmin')
-                | Add Trail URL
+            .btn-toolbar
+              button.btn.btn-sm.btn-default(ui-sref='app.dwTrails.list',title='To Trails')
+                  i.fa.fa-arrow-up &nbsp;to Trails
+              a.btn.btn-sm.btn-success.glyphicon.glyphicon-plus.custom(ui-sref='^.add({trailId:currentTrailId})', ng-disabled='!currentUser.isAdmin')
+                | &nbsp;Add URL
       tbody
         tr(ng-repeat='trailUrl in displayedTrailUrls')
           td(style='width: 120px')
             a(href='', ui-sref='app.dwTrailUrls.view({id: trailUrl.id})') {{trailUrl.url}}
           td.td-center
-            a(ui-sref='app.dwUrlExtractions.list({id:null, id: trailUrl.id})') {{trailUrl.urlExtractions.length}}
+            a(ui-sref='app.dwUrlExtractions.list({id: trailUrl.id})') {{trailUrl.urlExtractions.length}}
           td
             span.label.label-ltgray {{trailUrl.trail.name}}
           td
@@ -34,7 +37,7 @@
           td.td-center(style='width: 120px')
             .btn-toolbar
                 button.btn.btn-sm.btn-default.glyphicon.glyphicon-eye-open(ng-click='openUrl({url:trailUrl.url})', title='Browse Url')
-                button.btn.btn-sm.btn-default(ui-sref='app.dwTrailUrls.edit({id:trailUrl.id})',ng-disabled='!currentUser.isAdmin',title='Edit Url')
+                button.btn.btn-sm.btn-default(ui-sref='app.dwTrailUrls.edit({id:trailUrl.id, trailId:currentTrailId})',ng-disabled='!currentUser.isAdmin',title='Edit Url')
                     i.fa.fa-pencil
                 button.btn.btn-sm.btn-danger(ng-click='delete({id:trailUrl})',ng-disabled='!currentUser.isAdmin')
                     i.fa.fa-trash-o

--- a/client/app/modules/dwTrailUrls/views/list.jade
+++ b/client/app/modules/dwTrailUrls/views/list.jade
@@ -9,7 +9,7 @@
       thead
         tr
           th.sortable.col-sm-3.col-md-3.col-lg-3(st-sort='url' st-sort-default="true") URL
-          th.col-sm-1.col-md-1.col-lg-1.td-center.text-nowrap # Extractions
+          th.sortable.col-sm-1.col-md-1.col-lg-1(st-sort='urlExtractions.length') # Extractions
           th.sortable.col-sm-1.col-md-1.col-lg-1(st-sort='trail.name') Trail
           th.sortable.col-sm-1.col-md-1.col-lg-1.text-nowrap(st-sort='dwCrawlTypeId') Crawl Type
           th.sortable.col-sm-2.col-md-2.col-lg-2(st-sort='comments') Comments

--- a/client/app/modules/dwTrailUrls/views/list.jade
+++ b/client/app/modules/dwTrailUrls/views/list.jade
@@ -25,7 +25,7 @@
           td(style='width: 120px')
             a(href='', ui-sref='app.dwTrailUrls.view({id: trailUrl.id})') {{trailUrl.url}}
           td.td-center
-            a(ui-sref='app.dwUrlExtractions.list({id: trailUrl.id})') {{trailUrl.urlExtractions.length}}
+            a(ui-sref='app.dwUrlExtractions.list({id: null, trailUrlId: trailUrl.id})') {{trailUrl.urlExtractions.length}}
           td
             span.label.label-ltgray {{trailUrl.trail.name}}
           td

--- a/client/app/modules/dwTrails/views/list.jade
+++ b/client/app/modules/dwTrails/views/list.jade
@@ -37,7 +37,7 @@
           td.td-center
             span.label.label-ltgray(ng-repeat="user in trail.users") {{user.username}}
           td.td-center
-            a(ui-sref='app.dwTrailUrls.list({id:null, domainId:domain.id})') {{trail.trailUrls.length}}
+            a(ui-sref='app.dwTrailUrls.list({id:null, trailId:trail.id})') {{trail.trailUrls.length}}
           td.td-center
             span.label.label-ltgray(ng-repeat="feed in trail.feeds") {{feed.name}}
           td

--- a/client/app/modules/dwTrails/views/list.jade
+++ b/client/app/modules/dwTrails/views/list.jade
@@ -11,15 +11,14 @@
           th.sortable.col-sm-1.col-md-1.col-lg-1(st-sort='name' st-sort-default="true") Name
           th.sortable.col-sm-2.col-md-2.col-lg-2(st-sort='description') Description
           th.sortable.col-sm-1.col-md-1.col-lg-1(st-sort='team') Team
-          th.sortable.col-sm-1.col-md-1.col-lg-1.td-center.text-nowrap(st-sort='domainId') Domain
+          th.sortable.col-sm-1.col-md-1.col-lg-1.td-center.text-nowrap(st-sort='domain.name') Domain
           th.sortable.col-sm-1.col-md-1.col-lg-1(st-sort='scrape') Scrape
-          th.sortable.col-sm-1.col-md-1.col-lg-1.td-center.text-nowrap(st-sort='userId') # Users
-          th.sortable.col-sm-1.col-md-1.col-lg-1.td-center.text-nowrap(st-sort='') # URLs
+          th.sortable.col-sm-1.col-md-1.col-lg-1.td-center.text-nowrap(st-sort='') # Users
+          th.sortable.col-sm-1.col-md-1.col-lg-1.td-center.text-nowrap(st-sort='trailUrls.length') # URLs
           th.sortable.col-sm-1.col-md-1.col-lg-1.td-center(st-sort='') Feeds
           th.sortable.col-sm-2.col-md-2.col-lg-2(st-sort='timestamp') Timestamp
           th.col-sm-2.col-md-2.col-lg-2.td-center
-              a.btn.btn-sm.btn-success.glyphicon.glyphicon-plus.custom(ui-sref='^.add')
-                | Add Trail
+              a.btn.btn-sm.btn-success.glyphicon.glyphicon-plus.custom(ui-sref='^.add') &nbsp;Add Trail
       tbody
         tr(ng-repeat='trail in displayedTrails')
           td.hidden

--- a/client/app/modules/dwUrlExtractions/config/urlExtractions.routes.js
+++ b/client/app/modules/dwUrlExtractions/config/urlExtractions.routes.js
@@ -6,20 +6,20 @@ app.config(function($stateProvider) {
         abstract: true,
         url: '/dwUrlExtractions',
         templateUrl: 'modules/dwUrlExtractions/views/main'
-    }).state('app.dwUrlExtractions.list', {
-        url: '',
-        templateUrl: 'modules/dwUrlExtractions/views/list',
-        controller: 'UrlExtractionsCtrl'
     }).state('app.dwUrlExtractions.add', {
-        url: '/add',
+        url: '/add/:trailUrlId',
         templateUrl: 'modules/dwUrlExtractions/views/form',
         controller: 'UrlExtractionsCtrl'
+    }).state('app.dwUrlExtractions.list', {
+        url: '/list/:trailUrlId',
+        templateUrl: 'modules/dwUrlExtractions/views/list',
+        controller: 'UrlExtractionsCtrl'
     }).state('app.dwUrlExtractions.edit', {
-        url: '/:id/edit',
+        url: '/edit/:id/:trailUrlId',
         templateUrl: 'modules/dwUrlExtractions/views/form',
         controller: 'UrlExtractionsCtrl'
     }).state('app.dwUrlExtractions.view', {
-        url: '/:id',
+        url: '/view/:id',
         templateUrl: 'modules/dwUrlExtractions/views/view',
         controller: 'UrlExtractionsCtrl'
     });

--- a/client/app/modules/dwUrlExtractions/controllers/urlExtractions.ctrl.js
+++ b/client/app/modules/dwUrlExtractions/controllers/urlExtractions.ctrl.js
@@ -7,6 +7,8 @@ app.controller('UrlExtractionsCtrl', function($scope, $state, $stateParams, DwDo
   $scope.currentUser = AppAuth.currentUser;
   $scope.domainEntityTypes = [];
   $scope.trailUrls = [];
+  $scope.currentTrailUrlId = '';
+  $scope.urlExtraction = {};
 
   $scope.formFields = [{
     key: 'id',
@@ -53,7 +55,6 @@ app.controller('UrlExtractionsCtrl', function($scope, $state, $stateParams, DwDo
       }
   }];
 
-
   $scope.delete = function(id) {
     UrlExtractionsService.deleteUrlExtraction(id, function() {
       $scope.safeDisplayedurlExtractions = UrlExtractionsService.getUrlExtractions();
@@ -70,21 +71,21 @@ app.controller('UrlExtractionsCtrl', function($scope, $state, $stateParams, DwDo
 
   $scope.makeDomainItem = function(extractedItem){
       alert('Create Domain Item:' + extractedItem.id.value);
-  }
+  };
 
   $scope.loading = true;
-  DwUrlExtraction.find({filter: {include: [{relation:'trailUrl',scope:{include: ['trail']}},'domainEntityType']}}).$promise
-      .then(function (allUrlExtractions) {
-        $scope.safeDisplayedurlExtractions = allUrlExtractions;
-        $scope.displayedUrlExtractions = [].concat($scope.safeDisplayedurlExtractions);
-      })
-      .catch(function (err) {
-        console.log(err);
-      })
-      .then(function () {
-        $scope.loading = false;
-      }
-  );
+  //DwUrlExtraction.find({filter: {include: [{relation:'trailUrl',scope:{include: ['trail']}},'domainEntityType']}}).$promise
+  //    .then(function (allUrlExtractions) {
+  //      $scope.safeDisplayedurlExtractions = allUrlExtractions;
+  //      $scope.displayedUrlExtractions = [].concat($scope.safeDisplayedurlExtractions);
+  //    })
+  //    .catch(function (err) {
+  //      console.log(err);
+  //    })
+  //    .then(function () {
+  //      $scope.loading = false;
+  //    }
+  //);
 
   DwDomainEntityType.find({filter: {include: []}}).$promise
       .then(function (allEntTypes) {
@@ -120,11 +121,30 @@ app.controller('UrlExtractionsCtrl', function($scope, $state, $stateParams, DwDo
       }
   );
 
-  if ($stateParams.id) {
+  if ($stateParams.id && $stateParams.trailUrlId) {
     UrlExtractionsService.getUrlExtraction($stateParams.id).$promise.then(function(result){
-      $scope.urlExtraction = result;})
+      $scope.currentTrailUrlId = $stateParams.trailUrlId;
+      $scope.urlExtraction = result;
+      $scope.safeDisplayedurlExtractions = {};
+      $scope.displayedUrlExtractions = {};
+      $scope.loading = false;
+    })
+  } else if ($stateParams.trailUrlId){
+      UrlExtractionsService.getFilteredUrlExtractions($stateParams.trailUrlId).$promise.then(function(result){
+          $scope.currentTrailUrlId = $stateParams.trailUrlId;
+          $scope.urlExtraction = {};
+          $scope.safeDisplayedurlExtractions = result;
+          $scope.displayedUrlExtractions = [].concat($scope.safeDisplayedurlExtractions);
+          $scope.loading = false;
+      })
   } else {
-    $scope.urlExtraction = {};
+      UrlExtractionsService.getUrlExtractions().$promise.then(function(result) {
+          $scope.currentTrailUrlId = '';
+          $scope.urlExtraction = {};
+          $scope.safeDisplayedurlExtractions = result;
+          $scope.displayedUrlExtractions = [].concat($scope.safeDisplayedurlExtractions);
+          $scope.loading = false;
+      });
   }
 
 });

--- a/client/app/modules/dwUrlExtractions/services/trailUrls.service.js
+++ b/client/app/modules/dwUrlExtractions/services/trailUrls.service.js
@@ -13,6 +13,25 @@ app.service('UrlExtractionsService', ['$state', 'CoreService', 'DwUrlExtraction'
     });
   };
 
+  this.getFilteredUrlExtractions = function(trailUrlId) {
+    var whereClause={
+        filter:{
+            order:"occurrences DESC",
+            where:{
+                dwTrailUrlId:trailUrlId
+            },
+            include:[
+                {relation:'trailUrl',scope:{include: ['trail']}},
+                'domainEntityType'
+            ]
+        }
+    };
+    return (DwUrlExtraction.find(whereClause));
+
+    //return DwUrlExtraction.find({filter: {include: [{relation:'trailUrl',scope:{include: ['trail']}},'domainEntityType']}});
+  };
+
+
   this.upsertUrlExtraction = function(urlExtraction, cb) {
     DwUrlExtraction.upsert(urlExtraction, function() {
       CoreService.toastSuccess(gettextCatalog.getString(

--- a/client/app/modules/dwUrlExtractions/views/form.jade
+++ b/client/app/modules/dwUrlExtractions/views/form.jade
@@ -2,7 +2,7 @@
   .box-header
     span.box-title
       .input-group
-        a.btn.btn-default(translate, href='', ui-sref='^.list', style='float: left;')
+        a.btn.btn-default(translate, href='', ui-sref='^.list({trailUrlId: currentTrailUrlId })', style='float: left;')
           i.fa.fa-arrow-left &nbsp;Back to URL Extractions
     .box-tools.pull-right
       span.pull-right.btn-toolbar

--- a/client/app/modules/dwUrlExtractions/views/list.jade
+++ b/client/app/modules/dwUrlExtractions/views/list.jade
@@ -14,9 +14,12 @@
           th.sortable.col-sm-2.col-md-2.col-lg-2(st-sort='trail.name') Trail
           th.sortable.col-sm-2.col-md-2.col-lg-3(st-sort='trailUrl.url') URL
           th.sortable.col-sm-2.col-md-2.col-lg-3(st-sort='trailUrl.occurrences') Occurrences
-          th.col-sm-2.col-md-2.col-lg-2.td-center
-              a.btn.btn-sm.btn-success.glyphicon.glyphicon-plus.custom(ui-sref='^.add', ng-disabled='!currentUser.isAdmin')
-                | Add UrlExtraction
+          th.col-sm-2.col-md-2.col-lg-2.td-
+            .btn-toolbar
+              button.btn.btn-sm.btn-default(ui-sref='app.dwTrailUrls.list',title='To Urls')
+                i.fa.fa-arrow-up &nbsp;to Urls
+              a.btn.btn-sm.btn-success.glyphicon.glyphicon-plus.custom(ui-sref='^.add({trailUrlId:currentTrailUrlId})', ng-disabled='!currentUser.isAdmin')
+                | &nbsp;Add Extraction
       tbody
         tr(ng-repeat='urlExtraction in displayedUrlExtractions')
           //td(style='width: 120px')
@@ -34,7 +37,7 @@
           td.td-center(style='width: 120px')
             .btn-toolbar
                 button.btn.btn-sm.btn-warning.glyphicon.glyphicon-save(ng-click='makeDomainItem({id:urlExtraction})', ng-disabled='!currentUser.isAdmin', title='Add as Domain Item')
-                button.btn.btn-sm.btn-default(ui-sref='app.dwUrlExtractions.edit({id:urlExtraction.id})',ng-disabled='!currentUser.isAdmin', title='Edit Extraction')
+                button.btn.btn-sm.btn-default(ui-sref='app.dwUrlExtractions.edit({id:urlExtraction.id,trailUrlId:currentTrailUrlId})',ng-disabled='!currentUser.isAdmin', title='Edit Extraction')
                     i.fa.fa-pencil
                 button.btn.btn-sm.btn-danger(ng-click='delete({id:urlExtraction.id})',ng-disabled='!currentUser.isAdmin', title='Delete Extraction')
                     i.fa.fa-trash-o

--- a/client/app/modules/dwUrlExtractions/views/list.jade
+++ b/client/app/modules/dwUrlExtractions/views/list.jade
@@ -9,11 +9,11 @@
       thead
         tr
           //th.sortable.col-sm-2.col-md-2.col-lg-2.text-nowrap(st-sort='domainEntityType.name' st-sort-default="true") Entity Type
-          th.sortable.col-sm-2.col-md-2.col-lg-3(st-sort='value') Value
-          th.sortable.col-sm-2.col-md-2.col-lg-3(st-sort='types') Types
+          th.sortable.col-sm-2.col-md-2.col-lg-2(st-sort='value') Value
+          th.sortable.col-sm-2.col-md-2.col-lg-2(st-sort='types') Types
           th.sortable.col-sm-2.col-md-2.col-lg-2(st-sort='trail.name') Trail
-          th.sortable.col-sm-2.col-md-2.col-lg-3(st-sort='trailUrl.url') URL
-          th.sortable.col-sm-2.col-md-2.col-lg-3(st-sort='trailUrl.occurrences') Occurrences
+          th.sortable.col-sm-2.col-md-2.col-lg-2(st-sort='trailUrl.url') URL
+          th.sortable.col-sm-1.col-md-1.col-lg-1(st-sort='trailUrl.occurrences') Occurrences
           th.col-sm-2.col-md-2.col-lg-2.td-
             .btn-toolbar
               button.btn.btn-sm.btn-default(ui-sref='app.dwTrailUrls.list',title='To Urls')

--- a/script/_build-lb-services.sh
+++ b/script/_build-lb-services.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+lb-ng ../server/server.js ../client/app/js/lb-services.js

--- a/server/boot/extractorService.js
+++ b/server/boot/extractorService.js
@@ -200,7 +200,8 @@ module.exports = function (app) {
                                                     headers: headers,
                                                     form: {
                                                         dwTrailUrlId: change.data.id.toString(),
-                                                        scrapedContent: change.data.scrapedContent.indexOf("PK") == 0 ? me.unzipContent(change.data.scrapedContent) : change.data.scrapedContent
+                                                        //scrapedContent: change.data.scrapedContent.indexOf("PK") == 0 ? me.unzipContent(change.data.scrapedContent) : change.data.scrapedContent
+                                                        scrapedContent:change.data.scrapedContent
                                                     }
                                                 }, function (error) {
                                                     if (error) {

--- a/server/boot/widgets.js
+++ b/server/boot/widgets.js
@@ -42,6 +42,11 @@ module.exports = function (app) {
 
         dwTrailUrl.findOne(whereClause,function (err, trailUrl) {
             if(err || !trailUrl || !trailUrl.urlExtractions){
+                res.render(renderPath,
+                    {
+                        "pageTitle": 'Extracted Entities',
+                        "extractedEntities": {}
+                    });
                 return;
             }
             trailUrl.urlExtractions(function(err,urlExt){

--- a/server/boot/widgets.js
+++ b/server/boot/widgets.js
@@ -40,16 +40,18 @@ module.exports = function (app) {
             "include":[{"relation":"urlExtractions","scope":{"where": {"extractorTypes": {"nin":["text"]}}, "order":"occurrences DESC"}}]
         };
 
-
         dwTrailUrl.findOne(whereClause,function (err, trailUrl) {
+            if(err || !trailUrl || !trailUrl.urlExtractions){
+                return;
+            }
             trailUrl.urlExtractions(function(err,urlExt){
                 var renderPath = serverPath.concat('/extractedEntityWidget/main');
-                res.render(renderPath, {
-                    "pageTitle": 'Extracted Entities',
-                    "extractedEntities": urlExt
-                });
-            })
-
+                    res.render(renderPath, {
+                        "pageTitle": 'Extracted Entities',
+                        "extractedEntities": urlExt
+                    });
+                }
+            )
         });
     });
 };

--- a/server/boot/widgets.js
+++ b/server/boot/widgets.js
@@ -34,7 +34,16 @@ module.exports = function (app) {
 
         var dwExtraction = app.models.DwUrlExtraction;
 
-        var whereClause= { "include": [{"relation":"trailUrl","scope":{"where":{"url":req.query.trailUrl}}}]};
+        var whereClause= {
+            "order": "occurrences DESC",
+            "include": [{
+                "relation":"trailUrl","scope":{
+                    "where":{
+                        "url":req.query.trailUrl
+                    }
+                }
+            }]
+        };
 
         dwExtraction.find(whereClause,function (err, extractions) {
 

--- a/server/boot/widgets.js
+++ b/server/boot/widgets.js
@@ -14,20 +14,6 @@ module.exports = function (app) {
 
         var dwDomain = app.models.DwDomain;
 
-        //dwDomain.find()
-        //    .then(function(domains){
-        //        // Called if the operation succeeds.
-        //        var x = domains;
-        //        var renderPath = serverPath.concat('/domainWidget/main');
-        //        res.render(renderPath, {
-        //            "pageTitle": 'Domain Listing',
-        //            "domainList": domains
-        //        });
-        //    })
-        //    .catch(function(err){
-        //        // Called if the operation encounters an error.
-        //    });
-
         dwDomain.find(function (err, domains) {
             var domainItems = [];
             domains.forEach(function (domain) {
@@ -37,6 +23,26 @@ module.exports = function (app) {
             res.render(renderPath, {
                 "pageTitle": 'Domain Listing',
                 "domainList": domainItems
+            });
+        });
+    });
+
+    app.get('/widget/get-url-entities', function (req, res) {
+        log('Retrieving Url Entities');
+        //JReeme sez: setMaxListeners so we don't have to see that ridiculous memory leak warning
+        app.models.DwUrlExtraction.getDataSource().setMaxListeners(0);
+
+        var dwExtraction = app.models.DwUrlExtraction;
+
+        dwExtraction.find(function (err, extractions) {
+            var extractionItems = [];
+            extractions.forEach(function (extraction) {
+                extractionItems.push({name:extraction.name, value: extraction.value, extractorTypes: extraction.extractorTypes});
+            });
+            var renderPath = serverPath.concat('/extractedEntityWidget/main');
+            res.render(renderPath, {
+                "pageTitle": 'Extracted Entities',
+                "extractedEntities": extractionItems
             });
         });
     });

--- a/server/boot/widgets.js
+++ b/server/boot/widgets.js
@@ -34,10 +34,22 @@ module.exports = function (app) {
 
         var dwExtraction = app.models.DwUrlExtraction;
 
-        dwExtraction.find(function (err, extractions) {
+        var whereClause= { "include": [{"relation":"trailUrl","scope":{"where":{"url":req.query.trailUrl}}}]};
+
+        dwExtraction.find(whereClause,function (err, extractions) {
+
             var extractionItems = [];
             extractions.forEach(function (extraction) {
-                extractionItems.push({name:extraction.name, value: extraction.value, extractorTypes: extraction.extractorTypes});
+                extraction.trailUrl(function(err,turl){
+                    if(turl) {
+                        extractionItems.push({
+                            occurrences: extraction.occurrences,
+                            value: extraction.value,
+                            extractorTypes: extraction.extractorTypes
+                        });
+                    }
+                });
+
             });
             var renderPath = serverPath.concat('/extractedEntityWidget/main');
             res.render(renderPath, {

--- a/server/boot/widgets.js
+++ b/server/boot/widgets.js
@@ -37,7 +37,7 @@ module.exports = function (app) {
         var whereClause={
             "order":"timestamp DESC",
             "where":{"url":req.query.trailUrl},
-            "include":[{"relation":"urlExtractions","scope":{"order":"occurrences DESC"}}]
+            "include":[{"relation":"urlExtractions","scope":{"where": {"extractorTypes": {"nin":["text"]}}, "order":"occurrences DESC"}}]
         };
 
 

--- a/server/boot/widgets.js
+++ b/server/boot/widgets.js
@@ -1,0 +1,45 @@
+'use strict';
+//var async = require('async');
+//var deepExtend = require('deep-extend');
+var log = require('debug')('routes');
+
+module.exports = function (app) {
+    var path = require('path');
+    var serverPath = path.join(__dirname,'../modules');
+
+    app.get('/widget/get-domain-list', function (req, res) {
+        log('Retrieving dwDomains');
+        //JReeme sez: setMaxListeners so we don't have to see that ridiculous memory leak warning
+        app.models.DwDomain.getDataSource().setMaxListeners(0);
+
+        var dwDomain = app.models.DwDomain;
+
+        //dwDomain.find()
+        //    .then(function(domains){
+        //        // Called if the operation succeeds.
+        //        var x = domains;
+        //        var renderPath = serverPath.concat('/domainWidget/main');
+        //        res.render(renderPath, {
+        //            "pageTitle": 'Domain Listing',
+        //            "domainList": domains
+        //        });
+        //    })
+        //    .catch(function(err){
+        //        // Called if the operation encounters an error.
+        //    });
+
+        dwDomain.find(function (err, domains) {
+            var domainItems = [];
+            domains.forEach(function (domain) {
+                domainItems.push({name:domain.name,description: domain.description});
+            });
+            var renderPath = serverPath.concat('/domainWidget/main');
+            res.render(renderPath, {
+                "pageTitle": 'Domain Listing',
+                "domainList": domainItems
+            });
+        });
+    });
+};
+
+

--- a/server/config.json
+++ b/server/config.json
@@ -4,5 +4,15 @@
   "port": 3000,
   "url": "http://localhost:3000/",
   "cookieSecret": "F1FEE670-3C72-11E4-916C-0800200C9A66",
+  "remoting": {
+    "json": {
+      "strict": false,
+      "limit": "50mb"
+    },
+    "urlencoded": {
+      "extended": true,
+      "limit": "50mb"
+    }
+  },
   "legacyExplorer": false
 }

--- a/server/modules/domainWidget/main.jade
+++ b/server/modules/domainWidget/main.jade
@@ -1,11 +1,11 @@
 div.DWD_widget(id='widgetOne')
-     table.DWD_table(border='1')
-         thead
-             tr
-                 th Name
-                 th Desc
-         tbody
-             each domain, i in domainList
-                 tr
-                     td #{domain.name}
-                     td #{domain.description}
+    table.DWD_table(border='1')
+        thead.DWD_th
+            tr.DWD_tr
+                th.DWD_th Name
+                th.DWD_th Desc
+        tbody
+            each domain, i in domainList
+                tr.DWD_tr
+                    td.DWD_td #{domain.name}
+                    td.DWD_td #{domain.description}

--- a/server/modules/domainWidget/main.jade
+++ b/server/modules/domainWidget/main.jade
@@ -1,17 +1,11 @@
-doctype html
-html
-   head
-    h1
-        #{pageTitle}
-   body
-    div(id='domains' class="container")
-        table(border='1')
-            thead
-                tr
-                    th Name
-                    th Desc
-            tbody
-                each domain, i in domainList
-                    tr
-                        td #{domain.name}
-                        td #{domain.description}
+div(id='domains' class="container")
+     table(border='1')
+         thead
+             tr
+                 th Name
+                 th Desc
+         tbody
+             each domain, i in domainList
+                 tr
+                     td #{domain.name}
+                     td #{domain.description}

--- a/server/modules/domainWidget/main.jade
+++ b/server/modules/domainWidget/main.jade
@@ -1,5 +1,5 @@
-div(id='domains' class="container")
-     table(border='1')
+div.DWD_widget(id='domains')
+     table.DWD_table(border='1')
          thead
              tr
                  th Name

--- a/server/modules/domainWidget/main.jade
+++ b/server/modules/domainWidget/main.jade
@@ -1,0 +1,17 @@
+doctype html
+html
+   head
+    h1
+        #{pageTitle}
+   body
+    div(id='domains' class="container")
+        table(border='1')
+            thead
+                tr
+                    th Name
+                    th Desc
+            tbody
+                each domain, i in domainList
+                    tr
+                        td #{domain.name}
+                        td #{domain.description}

--- a/server/modules/domainWidget/main.jade
+++ b/server/modules/domainWidget/main.jade
@@ -1,4 +1,4 @@
-div.DWD_widget(id='domains')
+div.DWD_widget(id='widgetOne')
      table.DWD_table(border='1')
          thead
              tr

--- a/server/modules/extractedEntityWidget/main.jade
+++ b/server/modules/extractedEntityWidget/main.jade
@@ -1,0 +1,12 @@
+div.DWD_widget(id='widgetOne')
+     table.DWD_table(border='1')
+         thead.DWD_th
+             tr.DWD_tr
+                 th.DWD_th Value
+                 th.DWD_th Occurrences
+         tbody
+             each entity, i in extractedEntities
+                 tr.DWD_tr
+                     td.DWD_td #{entity.value}
+                     td.DWD_td #{entity.occurrences}
+

--- a/server/modules/extractedEntityWidget/main.jade
+++ b/server/modules/extractedEntityWidget/main.jade
@@ -1,12 +1,15 @@
 div.DWD_widget(id='widgetOne')
-     table.DWD_table(border='1')
-         thead.DWD_th
-             tr.DWD_tr
-                 th.DWD_th Value
-                 th.DWD_th Occurrences
-         tbody
-             each entity, i in extractedEntities
-                 tr.DWD_tr
-                     td.DWD_td #{entity.value}
-                     td.DWD_td #{entity.occurrences}
+    div.DWD_table_container
+        table.DWD_table(border='1')
+            thead.DWD_th
+                tr.DWD_tr
+                     th.DWD_th Value
+                     th.DWD_th #
+                     th.DWD_th Types
+            tbody
+                each entity, i in extractedEntities
+                     tr.DWD_tr
+                         td.DWD_td #{entity.value}
+                         td.DWD_td #{entity.occurrences}
+                         td.DWD_td #{entity.extractorTypes}
 

--- a/server/modules/extractedEntityWidget/main.jade
+++ b/server/modules/extractedEntityWidget/main.jade
@@ -1,5 +1,6 @@
 div.DWD_widget(id='widgetOne')
     div.DWD_table_container
+        h3.DWD_h1 Extracted Entities
         table.DWD_table(border='1')
             thead.DWD_th
                 tr.DWD_tr


### PR DESCRIPTION
From mframe:

Completed initial panel functionality and Extracted Entity Widget. Refactored Depot Trail, TrailUrl, and Url Extraction modules to limit views to the appropriate context. Combined with #28 users this provides a way for users to drill down from trail -> trail urls -> url extractions (and back up). Add and Edit item functionality on each main list retains this context.
