### PR TITLE
Toolbar wrapping fix & create trail dialog positioning

### DIFF
--- a/browser-plugins/firefox/data/toolbarFrame.html
+++ b/browser-plugins/firefox/data/toolbarFrame.html
@@ -32,6 +32,7 @@
 
   <form class="form-horizontal">
     <div class="form-group">
+<!--Not exposing Team picklist now
       <label for="teamList"
              style="padding-left:0;padding-right:4px;visibility: hidden"
              class="control-label col-lg-1 col-md-1 col-sm-1 col-xs-1">Team:</label>
@@ -42,10 +43,12 @@
                 onchange="teamSelectionChanged()"
                 class="form-control btn-info input-sm"></select>
       </div>
-
+-->
+      <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
+      </div>
       <div id="toggleDiv"
               class="col-lg-2 col-md-2 col-sm-2 col-xs-2"
-           style="padding-left:4px;padding-right:2px;">
+           style="padding-left:0px;padding-right:2px;min-width: 310px">
         <span>
             <label for="toggleDomainItems" style="font-size:10px;padding-left:0;padding-right:5px;">Show Domain Items:</label>
             <img src="./images/OffButton_transparent.png"
@@ -67,42 +70,43 @@
         </span>
       </div>
 
-      <div id="domainDiv" style="visibility: visible">
-          <label for="domainList"
-                   style="padding-left:0;padding-right:4px;"
-                   class="control-label col-lg-1 col-md-1 col-sm-1 col-xs-1">Domain:</label>
-          <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1"
-               style="padding-left:0;padding-right:0;">
-              <select id="domainList"
-                      disabled="disabled"
-                      onchange="domainSelectionChanged()"
-                      class="form-control btn-info input-sm">
-              </select>
+          <div id="domainDiv" style="visibility: visible">
+              <label for="domainList"
+                       style="padding-left:0;padding-right:4px;"
+                       class="control-label col-lg-1 col-md-1 col-sm-1 col-xs-1">Domain:</label>
+              <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1"
+                   style="padding-left:0;padding-right:0;">
+                  <select id="domainList"
+                          disabled="disabled"
+                          onchange="domainSelectionChanged()"
+                          class="form-control btn-info input-sm">
+                  </select>
+              </div>
           </div>
-      </div>
 
-      <label for="trailList"
-             style="padding-left:0;padding-right:4px;"
-             class="control-label col-lg-1 col-md-1 col-sm-1 col-xs-1">Trail:</label>
-      <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1 select-editable"
-           style="padding-left:0;padding-right:0;visibility: visible">
-        <select id="trailList"
-                disabled="disabled"
-                onchange="trailSelectionChanged()"
-                class="form-control btn-info input-sm">
-        </select>
-        <input id="trailInput"
-               disable="disabled"
-               type="text"
-               name="trailInput"
-               onkeyup="trailSelectionChanged2()"
-               value=""
-               class="form-control btn-info input-sm"/>
-      </div>
+              <label for="trailList"
+                     style="padding-left:0;padding-right:4px;"
+                     class="control-label col-lg-1 col-md-1 col-sm-1 col-xs-1">Trail:</label>
+              <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1 select-editable"
+                   style="padding-left:0;padding-right:0;visibility: visible">
+                <select id="trailList"
+                        disabled="disabled"
+                        onchange="trailSelectionChanged()"
+                        class="form-control btn-info input-sm">
+                </select>
+                <input id="trailInput"
+                       disabled="disabled"
+                       type="text"
+                       name="trailInput"
+                       onkeyup="trailSelectionChanged2()"
+                       value=""
+                       class="form-control btn-info input-sm"/>
+              </div>
+
 
 
       <div id="buttonDiv">
-          <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2"
+          <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 pull-right"
                style="padding-left:4px;padding-right:2px;">
             <a id="addTrailButton"
                role="button"

--- a/browser-plugins/firefox/data/toolbarFrame.html
+++ b/browser-plugins/firefox/data/toolbarFrame.html
@@ -1,137 +1,127 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <link href="vendor/bootstrap/bootstrap.min.css"
-        rel="stylesheet"/>
-  <link href="vendor/bootstrap/bootstrap-theme.min.css"
-        rel="stylesheet"/>
-  <link href="toolbarFrame.css"
-        rel="stylesheet"/>
-  <!--  <script type="text/javascript"
-            src="vendor/superagent/superagent.js"></script>-->
-  <script type="text/javascript"
-          src="vendor/jquery/jquery-2.1.4.min.js"></script>
-  <script type="text/javascript"
-          src="toolbarFrame.js"></script>
-  <style>
-  </style>
+    <link href="vendor/bootstrap/bootstrap.min.css"
+          rel="stylesheet"/>
+    <link href="vendor/bootstrap/bootstrap-theme.min.css"
+          rel="stylesheet"/>
+    <link href="toolbarFrame.css"
+          rel="stylesheet"/>
+    <!--  <script type="text/javascript"
+       src="vendor/superagent/superagent.js"></script>-->
+    <script type="text/javascript"
+            src="vendor/jquery/jquery-2.1.4.min.js"></script>
+    <script type="text/javascript"
+            src="toolbarFrame.js"></script>
+    <style>
+    </style>
 </head>
 <body onload="onLoad()">
 <div>
-  <!--<div style="vertical-align: middle"
+    <!--<div style="vertical-align: middle"
        class="container-fluid">-->
-  <a id="openDWHome"
-     role="button"
-          onclick="openTab()">
-      <img src="./images/waveicon24.png"
-           id="waveImg"
-           style="margin-left: 6px;position: absolute;"
-           height="24"
-           width="24">
-  </a>
+    <a id="openDWHome"
+       role="button"
+       onclick="openTab()">
+        <img src="./images/waveicon24.png"
+             id="waveImg"
+             style="margin-left: 6px;position: absolute;"
+             height="24"
+             width="24">
+    </a>
+    <form class="form-horizontal">
+        <div class="form-group" style="min-width:1000px">
+            <!--Not exposing Team picklist now
+               <label for="teamList"
+                      style="padding-left:0;padding-right:4px;visibility: hidden"
+                      class="control-label col-lg-1 col-md-1 col-sm-1 col-xs-1">Team:</label>
+               <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3"
+                    style="padding-left:0;padding-right:0;visibility: hidden">
+                 <select id="teamList"
+                         disabled="disabled"
+                         onchange="teamSelectionChanged()"
+                         class="form-control btn-info input-sm"></select>
+               </div>
+               -->
 
-  <form class="form-horizontal">
-    <div class="form-group">
-<!--Not exposing Team picklist now
-      <label for="teamList"
-             style="padding-left:0;padding-right:4px;visibility: hidden"
-             class="control-label col-lg-1 col-md-1 col-sm-1 col-xs-1">Team:</label>
-      <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3"
-           style="padding-left:0;padding-right:0;visibility: hidden">
-        <select id="teamList"
-                disabled="disabled"
-                onchange="teamSelectionChanged()"
-                class="form-control btn-info input-sm"></select>
-      </div>
--->
-      <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
-      </div>
-      <div id="toggleDiv"
-              class="col-lg-2 col-md-2 col-sm-2 col-xs-2"
-           style="padding-left:0px;padding-right:2px;min-width: 310px">
-        <span>
-            <label for="toggleDomainItems" style="font-size:10px;padding-left:0;padding-right:5px;">Show Domain Items:</label>
-            <img src="./images/OffButton_transparent.png"
-                 id="toggleDomainItems"
-                 align="bottom"
-                 height="15"
-                 width="45"
-                 onclick="toggleDataItems()">
-        </span>
-
-        <span>
-            <label for="toggleDWPanel" style="font-size:10px;padding-left:0;padding-right:5px;">Show Panel:</label>
-                <img src="./images/OffButton_transparent.png"
-                     id="toggleDWPanel"
-                     align="bottom"
-                     height="15"
-                     width="45"
-                     onclick="togglePanel()">
-        </span>
-      </div>
-
-          <div id="domainDiv" style="visibility: visible">
-              <label for="domainList"
-                       style="padding-left:0;padding-right:4px;"
-                       class="control-label col-lg-1 col-md-1 col-sm-1 col-xs-1">Domain:</label>
-              <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1"
-                   style="padding-left:0;padding-right:0;">
-                  <select id="domainList"
-                          disabled="disabled"
-                          onchange="domainSelectionChanged()"
-                          class="form-control btn-info input-sm">
-                  </select>
-              </div>
-          </div>
-
-              <label for="trailList"
-                     style="padding-left:0;padding-right:4px;"
-                     class="control-label col-lg-1 col-md-1 col-sm-1 col-xs-1">Trail:</label>
-              <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1 select-editable"
-                   style="padding-left:0;padding-right:0;visibility: visible">
-                <select id="trailList"
-                        disabled="disabled"
-                        onchange="trailSelectionChanged()"
-                        class="form-control btn-info input-sm">
-                </select>
-                <input id="trailInput"
-                       disabled="disabled"
-                       type="text"
-                       name="trailInput"
-                       onkeyup="trailSelectionChanged2()"
-                       value=""
-                       class="form-control btn-info input-sm"/>
-              </div>
-
-
-
-      <div id="buttonDiv">
-          <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 pull-right"
-               style="padding-left:4px;padding-right:2px;">
-            <a id="addTrailButton"
-               role="button"
-               class="btn btn-sm btn-success"
-               style="display:none"
-               onclick="createTrail()">Add New Trail</a>
-            <a id="cancelTrailButton"
-               role="button"
-               style="display:none"
-               class="btn btn-sm btn-danger"
-               onclick="cancelTrail()">Cancel</a>
-            <a id="toggleTrailButton"
-               role="button"
-               class="btn btn-sm btn-success disabled"
-               onclick="toggleTrailing()">Start</a>
-
-            <a id="loginButton"
-               role="button"
-               class="btn btn-sm btn-primary"
-               onclick="toggleLogin()">Login</a>
-          </div>
-      </div>
-
-    </div>
-  </form>
+            <div id="toggleDiv"
+                 class="col-lg-2 col-md-2 col-sm-2 col-xs-2"
+                 style="padding-left:80px;padding-right:2px;min-width: 390px">
+                  <span>
+                  <label for="toggleDomainItems" style="font-size:10px;padding-left:0;padding-right:5px;">Show Domain Items:</label>
+                  <img src="./images/OffButton_transparent.png"
+                       id="toggleDomainItems"
+                       align="bottom"
+                       height="15"
+                       width="45"
+                       onclick="toggleDataItems()">
+                  </span>
+                  <span>
+                  <label for="toggleDWPanel" style="font-size:10px;padding-left:0;padding-right:5px;">Show Panel:</label>
+                  <img src="./images/OffButton_transparent.png"
+                       id="toggleDWPanel"
+                       align="bottom"
+                       height="15"
+                       width="45"
+                       onclick="togglePanel()">
+                  </span>
+            </div>
+            <div id="domainDiv" style="visibility: visible">
+                <label for="domainList"
+                       style="padding-left:0;padding-right:4px;white-space:nowrap;padding-top:7px;margin-bottom:0;text-align:right;"
+                       class="col-lg-1 col-md-1 col-sm-1 col-xs-1">Domain:</label>
+                <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1"
+                     style="padding-left:0;padding-right:0;white-space:nowrap;">
+                    <select id="domainList"
+                            disabled="disabled"
+                            onchange="domainSelectionChanged()"
+                            class="form-control btn-info input-sm">
+                    </select>
+                </div>
+                <label for="trailList"
+                       style="padding-left:0;padding-right:4px;white-space:nowrap;padding-top:7px;margin-bottom:0;text-align:right;"
+                       class="col-lg-1 col-md-1 col-sm-1 col-xs-1">Trail:</label>
+                <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1 select-editable"
+                     style="padding-left:0;padding-right:0;visibility: visible;white-space:nowrap;">
+                    <select id="trailList"
+                            disabled="disabled"
+                            onchange="trailSelectionChanged()"
+                            class="form-control btn-info input-sm">
+                    </select>
+                    <input id="trailInput"
+                           disabled="disabled"
+                           type="text"
+                           name="trailInput"
+                           onkeyup="trailSelectionChanged2()"
+                           value=""
+                           class="form-control btn-info input-sm"/>
+                </div>
+            </div>
+            <div id="buttonDiv">
+                <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 pull-right"
+                     style="padding-left:4px;padding-right:2px;min-width: 200px">
+                    <a id="addTrailButton"
+                       role="button"
+                       class="btn btn-sm btn-success"
+                       style="display:none"
+                       onclick="createTrail()">Add New Trail</a>
+                    <a id="cancelTrailButton"
+                       role="button"
+                       style="display:none"
+                       class="btn btn-sm btn-danger"
+                       onclick="cancelTrail()">Cancel</a>
+                    <a id="toggleTrailButton"
+                       role="button"
+                       class="btn btn-sm btn-success disabled"
+                       onclick="toggleTrailing()">Start</a>
+                    <a id="loginButton"
+                       role="button"
+                       class="btn btn-sm btn-primary"
+                       onclick="toggleLogin()">Login</a>
+                </div>
+            </div>
+        </div>
+    </form>
 </div>
 </body>
 </html>

--- a/browser-plugins/firefox/data/toolbarFrame.js
+++ b/browser-plugins/firefox/data/toolbarFrame.js
@@ -268,20 +268,20 @@ function trailSelectionChanged() {
 
 function lockToolbar(){
     $('#domainList').addClass('disabled');
-    $('#toggleDiv').hide();
-    $('#domainDiv').hide();
-    $('#toggleTrailButton').hide();
-    $('#loginButton').hide();
+    $('#toggleDiv').css('visibility','hidden');
+    $('#domainDiv').css('visibility','hidden');
+    $('#toggleTrailButton').css('visibility','hidden');
+    $('#loginButton').css('visibility','hidden');
     $('#addTrailButton').show();
     $('#cancelTrailButton').show();
 }
 
 function unlockToolbar(){
     $('#domainList').removeAttr('disabled');
-    $('#toggleDiv').show();
-    $('#domainDiv').show();
-    $('#toggleTrailButton').show();
-    $('#loginButton').show();
+    $('#toggleDiv').css('visibility','visible');
+    $('#domainDiv').css('visibility','visible');
+    $('#toggleTrailButton').css('visibility','visible');
+    $('#loginButton').css('visibility','visible');
     $('#addTrailButton').hide();
     $('#cancelTrailButton').hide();
 }

--- a/browser-plugins/firefox/data/toolbarFrame.js
+++ b/browser-plugins/firefox/data/toolbarFrame.js
@@ -111,7 +111,7 @@ function toggleTrailing() {
 function setUIStateToLoggedIn(pluginState) {
   window.pluginState = pluginState;
   $('#loginButton')
-    .html('Logout: ' + pluginState.loggedInUser.username)
+    .html('Logout')
     .removeClass('btn-primary')
     .addClass('btn-danger');
   $('#teamList').removeAttr('disabled');


### PR DESCRIPTION
Two sets of fixes on this ticket.  The first was to prevent the toggle button section from unnaturally wrapping when reducing window size.  The second was to maintain position of the trail text area and button locations when entering "create trail" mode.
